### PR TITLE
Various improvements (check each commit separately)

### DIFF
--- a/chat_replay_downloader.py
+++ b/chat_replay_downloader.py
@@ -91,7 +91,7 @@ class ChatReplayDownloader:
     }
 
     __YT_HOME = 'https://www.youtube.com'
-    __YT_REGEX = r'(?:/|%3D|v=|vi=)([0-9A-z-_]{11})(?:[%#?&]|$)'
+    __YT_REGEX = r'(?:/|%3D|v=|vi=)([0-9A-Za-z-_]{11})(?:[%#?&]|$)'
     __YOUTUBE_API_BASE_TEMPLATE = '{}/youtubei/{}/{}?key={}'
 
     __TWITCH_REGEX = r'(?:/videos/|/v/)(\d+)'

--- a/chat_replay_downloader.py
+++ b/chat_replay_downloader.py
@@ -859,11 +859,19 @@ class ChatReplayDownloader:
         raise InvalidURL('The url provided ({}) is invalid.'.format(url))
 
 
+def get_chat_replay(url, start_time=0, end_time=None, message_type='messages', chat_type='live', callback=None, output_messages=None, **kwargs):
+    return ChatReplayDownloader().get_chat_replay(url, start_time, end_time, message_type, chat_type, callback, output_messages, **kwargs)
+
+def get_youtube_messages(url, start_time=0, end_time=None, message_type='messages', chat_type='live', callback=None, output_messages=None, **kwargs):
+    return ChatReplayDownloader().get_youtube_messages(url, start_time, end_time, message_type, chat_type, callback, output_messages, **kwargs)
+
+def get_twitch_messages(url, start_time=0, end_time=None, callback=None, output_messages=None, **kwargs):
+    return ChatReplayDownloader().get_twitch_messages(url, start_time, end_time, callback, output_messages, **kwargs)
+
 def _debug_dump(obj):
     return json.dumps(obj, indent=4, default=str)
 
-
-if __name__ == '__main__':
+def main(args):
     parser = argparse.ArgumentParser(
         description='A simple tool used to retrieve YouTube/Twitch chat from past broadcasts/VODs. No authentication needed!',
         formatter_class=argparse.RawTextHelpFormatter)
@@ -913,7 +921,7 @@ if __name__ == '__main__':
                              "(default: '%(default)s')")
 
     # preprocess any long-form '-' args into '--' args
-    args = ['-' + arg if len(arg) >= 3 and arg[0] == '-' and arg[1] != '-' else arg for arg in sys.argv[1:]]
+    args = ['-' + arg if len(arg) >= 3 and arg[0] == '-' and arg[1] != '-' else arg for arg in args]
 
     args = parser.parse_args(args)
 
@@ -938,13 +946,13 @@ if __name__ == '__main__':
         if signum:
             print(f"[{signal.Signals(signum).name}]", flush=True) # pylint: disable=no-member # pylint lies - signal.Signals does exist
 
-        global called_finalize_output
+        nonlocal called_finalize_output
         if called_finalize_output:
             return
         else:
             called_finalize_output = True
 
-        global num_of_messages
+        nonlocal num_of_messages
         if chat_messages and args.output:
             if(args.output.endswith('.json')):
                 num_of_messages = len(chat_messages)
@@ -990,7 +998,7 @@ if __name__ == '__main__':
             chat_downloader.print_item(item)
 
         def write_to_file(item):
-            global num_of_messages
+            nonlocal num_of_messages
 
             # Don't print if it is a ticker message (prevents duplicates)
             if 'ticker_duration' in item:
@@ -1008,7 +1016,7 @@ if __name__ == '__main__':
             if(args.output.endswith('.json')):
                 pass
             elif(args.output.endswith('.csv')):
-                fieldnames = []
+                pass
             else:
                 open(args.output, 'w').close()  # empty the file
                 callback = write_to_file
@@ -1035,13 +1043,6 @@ if __name__ == '__main__':
 
     finally:
         finalize_output()
-else:
-    # when used as a module
-    def get_chat_replay(url, start_time=0, end_time=None, message_type='messages', chat_type='live', callback=None, output_messages=None, **kwargs):
-        return ChatReplayDownloader().get_chat_replay(url, start_time, end_time, message_type, chat_type, callback, output_messages, **kwargs)
 
-    def get_youtube_messages(url, start_time=0, end_time=None, message_type='messages', chat_type='live', callback=None, output_messages=None, **kwargs):
-        return ChatReplayDownloader().get_youtube_messages(url, start_time, end_time, message_type, chat_type, callback, output_messages, **kwargs)
-
-    def get_twitch_messages(url, start_time=0, end_time=None, callback=None, output_messages=None, **kwargs):
-        return ChatReplayDownloader().get_twitch_messages(url, start_time, end_time, callback, output_messages, **kwargs)
+if __name__ == '__main__':
+    main(sys.argv[1:])

--- a/chat_replay_downloader.py
+++ b/chat_replay_downloader.py
@@ -169,7 +169,10 @@ class ChatReplayDownloader:
 
     def __session_get_json(self, url):
         """Make a request using the current session and get json data."""
-        json = self.__session_get(url).json()
+        try:
+            json = self.__session_get(url).json()
+        except json.JSONDecodeError as e:
+            raise ParsingError("Could not parse JSON from response to '{}':\n{}".format(url, e.doc)) from e
         #if self.debug_logger: self.debug_logger("=> JSON:\n{}", json)
         return json
 
@@ -659,7 +662,7 @@ if __name__ == '__main__':
             global num_of_messages
 
             # only file format capable of appending properly
-            with open(args.output, 'a', encoding='utf-8') as f:
+            with open(args.output, 'a', newline='', encoding='utf-8-sig') as f:
                 if('ticker_duration' not in item):  # needed for duplicates
                     num_of_messages += 1
                     print_item(item)
@@ -690,7 +693,7 @@ if __name__ == '__main__':
             if chat_messages and args.output:
                 if(args.output.endswith('.json')):
                     num_of_messages = len(chat_messages)
-                    with open(args.output, 'w') as f:
+                    with open(args.output, 'w', newline='', encoding='utf-8-sig') as f:
                         json.dump(chat_messages, f, sort_keys=True)
 
                 elif(args.output.endswith('.csv')):
@@ -700,7 +703,7 @@ if __name__ == '__main__':
                         fieldnames = list(set(fieldnames + list(message.keys())))
                     fieldnames.sort()
 
-                    with open(args.output, 'w', newline='', encoding='utf-8') as f:
+                    with open(args.output, 'w', newline='', encoding='utf-8-sig') as f:
                         fc = csv.DictWriter(f, fieldnames=fieldnames)
                         fc.writeheader()
                         fc.writerows(chat_messages)

--- a/chat_replay_downloader.py
+++ b/chat_replay_downloader.py
@@ -372,8 +372,11 @@ class ChatReplayDownloader:
         error = response.get('error')
         if error:
             # Error code 403 'The caller does not have permission' error likely means the stream was privated immediately while the chat is still active.
-            if error.get('code') == 403:
+            error_code = error.get('code')
+            if error_code == 403:
                 raise VideoUnavailable
+            elif error_code == 404:
+                raise VideoNotFound
             else:
                 raise ParsingError("JSON response to '{}' is error:\n{}".format(url, json.dumps(response)))
         info = response.get('continuationContents', {}).get('liveChatContinuation')
@@ -506,7 +509,11 @@ class ChatReplayDownloader:
                     break
 
                 except VideoUnavailable:
-                    print('Video now unavailable, stream may have been privated while live chat was still active.')
+                    print('Video not unavailable, stream may have been privated while live chat was still active.')
+                    break
+
+                except VideoNotFound:
+                    print('Video not found, stream may have been deleted while live chat was still active.')
                     break
 
                 if('actions' in info):

--- a/chat_replay_downloader.py
+++ b/chat_replay_downloader.py
@@ -863,14 +863,18 @@ class ChatReplayDownloader:
                                     })
                             abort_cond_checker.check()
 
-                        retry_wait_secs = random.randint(30, 45) # jitter
-                        self.logger.debug("Upcoming {} Retrying in {} secs (attempt {})", error_message, retry_wait_secs, attempt_ct)
+                        retry_wait_secs = random.randint(45, 60) # jitter
+                        if self.logger.isEnabledFor(logging.INFO):
+                            self.logger.info("Upcoming {} Retrying in {} secs (attempt {})",
+                                error_message.lower(), retry_wait_secs, attempt_ct)
                         time.sleep(retry_wait_secs)
                     else:
                         raise NoChatReplay(error_message)
                 else:
                     break
             continuation = continuation_by_title_map[continuation_title]
+            if self.logger.isEnabledFor(logging.INFO):
+                self.logger.info("Downloading {} for video: {}", continuation_title.lower(), config['title'])
 
             abort_cond_checker = None
             first_time = True

--- a/chat_replay_downloader.py
+++ b/chat_replay_downloader.py
@@ -744,37 +744,40 @@ if __name__ == '__main__':
 
     parser.add_argument('url', help='YouTube/Twitch video URL')
 
-    parser.add_argument('-start_time', '-from', default=0,
+    parser.add_argument('--start_time', '--from', default=0,
                         help='start time in seconds or hh:mm:ss\n(default: %(default)s)')
-    parser.add_argument('-end_time', '-to', default=None,
+    parser.add_argument('--end_time', '--to', default=None,
                         help='end time in seconds or hh:mm:ss\n(default: %(default)s = until the end)')
 
-    parser.add_argument('-message_type', choices=['messages', 'superchat', 'all'], default='messages',
+    parser.add_argument('--message_type', choices=['messages', 'superchat', 'all'], default='messages',
                         help='types of messages to include [YouTube only]\n(default: %(default)s)')
 
-    parser.add_argument('-chat_type', choices=['live', 'top'], default='live',
+    parser.add_argument('--chat_type', choices=['live', 'top'], default='live',
                         help='which chat to get messages from [YouTube only]\n(default: %(default)s)')
 
-    parser.add_argument('-output', '-o', default=None,
+    parser.add_argument('--output', '-o', default=None,
                         help='name of output file\n(default: %(default)s = print to standard output)')
 
-    parser.add_argument('-cookies', '-c', default=None,
+    parser.add_argument('--cookies', '-c', default=None,
                         help='name of cookies file\n(default: %(default)s)')
 
     parser.add_argument('--hide_output', action='store_true',
                         help='whether to hide output or not\n(default: %(default)s)')
 
-    parser.add_argument('-log_level',
+    parser.add_argument('--log_level',
                         choices=[name for level, name in logging._levelToName.items() if level != 0],
                         default=logging._levelToName[logging.WARNING],
                         help='log level, logged to standard output\n(default: %(default)s)')
 
-    parser.add_argument('-log_base_context', default='',
+    parser.add_argument('--log_base_context', default='',
                         help='lines logged to standard output are formatted as:\n'
                              '"[<log_level>][<datetime>][<log_base_context><video_id>] <message>" (without the quotes)\n'
                              "(default: '%(default)s')")
 
-    args = parser.parse_args()
+    # preprocess any long-form '-' args into '--' args
+    args = ['-' + arg if len(arg) >= 3 and arg[0] == '-' and arg[1] != '-' else arg for arg in sys.argv[1:]]
+
+    args = parser.parse_args(args)
 
     if(args.hide_output):
         f = open(os.devnull, 'w')

--- a/chat_replay_downloader.py
+++ b/chat_replay_downloader.py
@@ -188,7 +188,7 @@ class ChatReplayDownloader:
             # Retry doesn't have jitter functionality; following random usage is a poor man's version that only jitters backoff_factor across sessions.
             backoff_factor=random.uniform(1.0, 1.5),
             status_forcelist=[413, 429, 500, 502, 503, 504], # also retries on connection/read timeouts
-            method_whitelist=False))) # retry on any HTTP method (including GET and POST)
+            allowed_methods=False))) # retry on any HTTP method (including GET and POST)
 
         cj = MozillaCookieJar(cookies)
         if cookies is not None:

--- a/chat_replay_downloader.py
+++ b/chat_replay_downloader.py
@@ -117,7 +117,7 @@ class ChatReplayDownloader:
         lenient=True, format='[%(levelname)s][%(asctime)s]%(context)s %(message)s', datefmt=DATETIME_FORMAT)
 
     __HEADERS = {
-        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.111 Safari/537.36',
+        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.72 Safari/537.36',
         'Accept-Language': 'en-US, en'
     }
 

--- a/chat_replay_downloader.py
+++ b/chat_replay_downloader.py
@@ -162,12 +162,11 @@ class ChatReplayDownloader:
     def __session_get(self, url, post_payload=None):
         """Make a request using the current session."""
         if post_payload is None:
-            if self.debug_logger: self.debug_logger("HTTP GET {}", url)
+            #if self.debug_logger: self.debug_logger("HTTP GET {}", url)
             response = self.session.get(url, timeout=10)
             if self.debug_logger: self.debug_logger("HTTP GET {} => status={} len(text)={}", url, response.status_code, len(response.text))
         else:
             post_payload = json.dumps(post_payload)
-            if self.debug_logger: self.debug_logger("HTTP POST {} len(payload)={}", url, len(post_payload))
             #if self.debug_logger: self.debug_logger("HTTP POST {}\n{}", url, post_payload) # too verbose
             response = self.session.post(url, data=post_payload, timeout=10)
             if self.debug_logger: self.debug_logger("HTTP POST {} len(payload)={} => status={} len(text)={}", url, len(post_payload), response.status_code, len(response.text))
@@ -176,11 +175,11 @@ class ChatReplayDownloader:
     def __session_get_json(self, url, post_payload=None):
         """Make a request using the current session and get json data."""
         try:
-            json = self.__session_get(url, post_payload).json()
+            ret = self.__session_get(url, post_payload).json()
         except json.JSONDecodeError as e:
             raise ParsingError("Could not parse JSON from response to '{}':\n{}".format(url, e.doc)) from e
-        #if self.debug_logger: self.debug_logger("=> JSON:\n{}", json)
-        return json
+        #if self.debug_logger: self.debug_logger("=> JSON:\n{}", json.dumps(ret))
+        return ret
 
     def __timestamp_to_microseconds(self, timestamp):
         """
@@ -229,7 +228,7 @@ class ChatReplayDownloader:
         [datetime] (author_type) *money* author: message,
         where (author_type) and *money* are optional.
         """
-        return '[{}] {}{}{}: {}'.format(
+        return '[{}] {}{}{}:\t{}'.format(
             item['datetime'] if 'datetime' in item else (
                 item['time_text'] if 'time_text' in item else ''),
             '({}) '.format(item['author_type'].lower()) if 'author_type' in item else '',
@@ -305,7 +304,7 @@ class ChatReplayDownloader:
         if not m:
             raise ParsingError('Unable to parse video data. Please try again.')
         ytcfg, _ = json_decoder.raw_decode(m.group(1))
-        if self.debug_logger: self.debug_logger("ytcfg:\n{}", json.dumps(ytcfg, indent=4))
+        #if self.debug_logger: self.debug_logger("ytcfg:\n{}", json.dumps(ytcfg, indent=4)) # too verbose
 
         config = {
             'api_version': ytcfg['INNERTUBE_API_VERSION'],
@@ -319,7 +318,7 @@ class ChatReplayDownloader:
             raise ParsingError('Unable to parse video data. Please try again.')
 
         ytInitialData, _ = json_decoder.raw_decode(m.group(1))
-        if self.debug_logger: self.debug_logger("ytInitialData:\n{}", json.dumps(ytInitialData, indent=4))
+        #if self.debug_logger: self.debug_logger("ytInitialData:\n{}", json.dumps(ytInitialData, indent=4)) # too verbose
 
         contents = ytInitialData.get('contents')
         if(not contents):

--- a/ioutils.py
+++ b/ioutils.py
@@ -1,0 +1,68 @@
+from datetime import datetime
+
+class TimestampPrefixFileWrapper:
+    """
+    Intended to wrap file-like objects like sys.stdout/stderr in cases where logging module shouldn't be used
+    (e.g. logging module outputs its own errors to stderr, so this can be used to wrap stderr).
+    """
+
+    __slots__ = 'f', 'datefmt', 'next_line_needs_prefix'
+
+    def __init__(self, f, datefmt):
+        self.f = f
+        self.datefmt = datefmt
+        self.next_line_needs_prefix = True
+
+    def write(self, s):
+        if s == '':
+            self.f.write('')
+            return
+        lines = s.splitlines(keepends=True) # since s != '', len(lines) >= 1
+        if self.next_line_needs_prefix or len(lines) != 1:
+            if self.next_line_needs_prefix:
+                lines.insert(0, '')
+            s = f"[{datetime.now():{self.datefmt}}] ".join(lines)
+        self.f.write(s)
+        last_line = lines[-1] # since keepends=True, guaranteed to be non-empty
+        self.next_line_needs_prefix = len(last_line.splitlines()[0]) != len(last_line) # handles universal newlines
+
+    def flush(self): # explicit def for efficiency
+        self.f.flush()
+
+    def __getattr__(self, name):
+        return self.f.__getattr__(self, name)
+
+class MultiFile:
+    """
+    Intended for allowing multiple outputs for a single file object.
+    
+    Based off https://stackoverflow.com/a/16551730
+    """
+
+    __slots__ = 'files', 'attrwraps'
+
+    def __init__(self, *files):
+        self.files = files
+        self.attrwraps = {}
+
+    # explicit def for efficiency
+    def write(self, s):
+        for f in self.files:
+            f.write(s)
+
+    # explicit def for efficiency
+    def flush(self):
+        for f in self.files:
+            f.flush()
+
+    # for any other method, delegate to slower __getattr__
+    def __getattr__(self, attr, *args):
+        attr = self.attrwraps.get(attr)
+        if attr is not None:
+            return attr
+        def wrap(*args2, **kwargs2):
+            for f in self.files:
+                result = getattr(f, attr, *args)(*args2, **kwargs2)
+            return result
+        self.attrwraps[attr] = wrap
+        return wrap

--- a/loggingutils.py
+++ b/loggingutils.py
@@ -402,7 +402,7 @@ class DateFileHandler(logging.FileHandler):
             old_stream = self.setStream(super()._open())
             try:
                 old_stream.close()
-            except:
+            except Exception: # don't catch non-Exceptions like KeyboardInterrupt
                 traceback.print_exc(file=sys.stderr)
         super().emit(record)
 

--- a/loggingutils.py
+++ b/loggingutils.py
@@ -1,0 +1,464 @@
+import logging
+import string
+import time
+from datetime import datetime
+import collections.abc
+import sys
+import os
+import contextlib
+import traceback
+import inspect
+import atexit
+
+class loggerProperty:
+    """
+    This descriptor serves multiple purposes:
+    1. Workaround for class variable initialization unable to access current class name.
+    2. Delay actual logging until logging is "initialized" (determined by len(logging.root.handlers) != 0)
+    The created logger doesn't define its own level or handlers by default, but that can be configured via logger_init.
+
+    `loggingutils.basicConfig` keyword arguments (including `lenient` and `propagate`) can also be passed to loggerProperty.
+    If any such arguments are passed (`**basic_config_kwargs`), `loggingutils.basicConfig(logger, **basic_config_kwargs)`
+    will be called upon first access of the logger property.
+
+    `logger_init(logger, instance, owner)` is called upon first access of the logger property,
+    after the above optional `loggingutils.basicConfig` call.
+
+    `loggerProperty` can be used as a decorator, e.g.
+        @loggerProperty(...)
+        def logger(self, instance, owner): # where self is the new logger
+            return ...
+    is effectively equivalent to:
+        logger = loggerProperty(logger_init=lambda self, instance, owner: ..., ...)
+    """
+
+    __slots__ = 'logger', 'actual_logger', 'logger_name', 'logger_init', 'basic_config_kwargs'
+
+    def __init__(self, logger_name=None, logger_init=None, **basic_config_kwargs):
+        self.logger = None
+        self.actual_logger = None
+        self.logger_name = logger_name
+        self.logger_init = logger_init
+        self.basic_config_kwargs = basic_config_kwargs
+
+    def __call__(self, logger_init):
+        self.logger_init = logger_init
+        return self
+
+    def __get__(self, instance=None, owner=None):
+        if self.logger is None:
+            if not self.logger_name:
+                self.logger_name = instance.__class__.__qualname__ if instance else owner.__qualname__ if owner else None
+            orig_logger = logging.getLogger(self.logger_name)
+            if self.basic_config_kwargs:
+                basicConfig(orig_logger, **self.basic_config_kwargs)
+            if self.logger_init:
+                self.logger_init = self.resolve_func(self.logger_init, instance, owner)
+                self.logger = self.logger_init(orig_logger, instance, owner)
+            else:
+                self.logger = orig_logger
+            self.actual_logger = getLogger(self.logger) # ensure we get the Logger and not a LoggerAdapter
+            if self.logging_uninitialized():
+                self.logger = _PreinitLogger(self.logger, self)
+        elif isinstance(self.logger, _PreinitLogger):
+            self.logger._try_preinit_flush()
+        return self.logger
+
+    def logging_uninitialized(self):
+        return len(logging.root.handlers) == 0 # assume this means that logging isn't initialized yet
+
+    # allow given func to be a descriptor like a staticmethod-wrapped function
+    @staticmethod
+    def resolve_func(func, instance, owner):
+        while (get := getattr(func, '__get__', None)) is not None:
+            next_func = get(instance, owner) # pylint: disable=not-callable # __get__ should be callable
+            if next_func is None or func is next_func: # if func is a method, func.__get__(...) is func
+                break
+            func = next_func
+        return func
+
+# if loggingProperty.logging_uninitialized(), this is used to hold log records until logging is initialized
+class _PreinitLogger(logging.LoggerAdapter):
+    __slots__ = '_logger_property', '_orig_level', '_preinit_records'
+
+    _TEMP_LOG_LEVEL = -9999
+
+    def __init__(self, logger, logger_property):
+        super().__init__(logger, None)
+        actual_logger = logger_property.actual_logger
+        self._logger_property = logger_property
+        self._orig_level = actual_logger.level
+        self._preinit_records = []
+        actual_logger.addFilter(self._preinit_filter) # filter is convenient for capturing created records
+        actual_logger.level = self._TEMP_LOG_LEVEL # since log level check happens before filter, ensure that check always succeeds
+        atexit.register(self._preinit_flush)
+
+    def log(self, level, msg, *args, **kwargs):
+        # note: client code may still be using this instance even after logging is initialized
+        # (e.g. if it doesn't get the logger property again after logging is initialized),
+        # so this still needs to be functional after logging is initialized
+        self._try_preinit_flush()
+        return self.logger.log(level, msg, *args, **kwargs)
+
+    def _preinit_filter(self, record):
+        if self._try_preinit_flush():
+            return True
+        self._preinit_records.append(record)
+        return False
+
+    def _try_preinit_flush(self):
+        if self._logger_property and not self._logger_property.logging_uninitialized():
+            self._preinit_flush()
+            return True
+        return False
+
+    def _preinit_flush(self):
+        actual_logger = self._logger_property.actual_logger
+        actual_logger.removeFilter(self._preinit_filter)
+        actual_logger.setLevel(self._orig_level)
+        self._logger_property.logger = self.logger
+        for record in self._preinit_records:
+            if actual_logger.isEnabledFor(record.levelno): # recheck log level
+                actual_logger.handle(record)
+        self._preinit_records.clear()
+        atexit.unregister(self._preinit_flush)
+        self._logger_property = None
+
+
+# copy of logging._StderrHandler, replacing stderr with stdout
+class StdoutHandler(logging.StreamHandler):
+    """
+    This class is like a StreamHandler using sys.stdout, but always uses
+    whatever sys.stderr is currently set to rather than the value of
+    sys.stdout at handler construction time.
+    """
+    def __init__(self, level=logging.NOTSET):
+        """
+        Initialize the handler.
+        """
+        logging.Handler.__init__(self, level)
+
+    @property
+    def stream(self):
+        return sys.stdout
+
+
+# for parity with above StdoutHandler
+StderrHandler = logging._StderrHandler
+
+
+class lenientFormatStyle(contextlib.ContextDecorator):
+    """
+    Provides a context where when initializing `Formatter`s, the format string can contain substitution keywords
+    (e.g. `%(key)s` for '%' style, `{key}` for '{' style, `${key}` for '$' style) that don't match any attributes in
+    `LogRecord` or keys in the `extra` dict (whether passed via logger calls or via `LoggerAdapter`.
+
+    Normally, this would cause the logging of the record to fail (logged to `stderr` by default - see `Handler.handleError`).
+    In the "lenient" context this class provides, such failed substitutions instead result in empty strings being substituted.
+
+    This class can be used in one of two ways:
+    * as a context manager:
+        with lenientFormatStyle():
+            ... Formatter(...) # only Formatter construction needs to be done in the with block
+    * as a decorator:
+        @lenientFormatStyle()
+        def foo(...):
+            ... Formatter(...) # only Formatter construction needs to be done in the function
+    """
+
+    class PercentStyle(logging.PercentStyle):
+        def _format(self, record):
+            return self._fmt % _LenientMapWrapper(record.__dict__)
+
+    class StrFormatStyle(logging.StrFormatStyle):
+        def _format(self, record):
+            return _LenientFormatter().vformat(self._fmt, (), record.__dict__)
+
+    class StringTemplateStyle(logging.StringTemplateStyle):
+        def _format(self, record):
+            return self._tpl.substitute(_LenientMapWrapper(record.__dict__))
+
+    __slots__ = 'orig_STYLES'
+
+    _STYLES = {
+        '%': (PercentStyle, logging._STYLES['%'][1]),
+        '{': (StrFormatStyle, logging._STYLES['{'][1]),
+        '$': (StringTemplateStyle, logging._STYLES['$'][1]),
+    }
+
+    def __enter__(self):
+        logging._acquireLock()
+        self.orig_STYLES = logging._STYLES
+        logging._STYLES = self._STYLES
+
+    def __exit__(self, *exc):
+        logging._STYLES = self.orig_STYLES
+        logging._releaseLock()
+
+class _LenientFormatter(string.Formatter):
+    __slots__ = ()
+    def get_value(self, key, args, kwargs):
+        try:
+            return super().get_value(key, args, kwargs)
+        except LookupError:
+            return ''
+
+class _LenientMapWrapper(collections.abc.Mapping):
+    __slots__ = 'map'
+    def __init__(self, map):
+        self.map = map
+    def __getitem__(self, key):
+        return self.map.get(key, '')
+    def __iter__(self):
+        return iter(self.map)
+    def __len__(self):
+        return len(self.map)
+    def __str__(self):
+        return str(self.map)
+    def __repr__(self):
+        return repr(self.map)
+
+
+class FormatLoggerAdapter(logging.LoggerAdapter):
+    """
+    `LoggerAdapter` that allows usage of any format style: `printf` ('%'), `str.format`/`string.Formatter` ('{'), `string.Template` ('$')
+    in `logger.log(level, msg_format, ...)` and `logger.<level>(msg_format, ...)` calls.
+
+    This does not affect how the format string in `Formatter` is handled, so it's possible to have a `FormatLoggerAdapter` over a logger
+    with a handler's formatter having different format `style`s.
+    """
+
+    __slots__ = 'style'
+
+    log_kwarg_names = [param.name for param in inspect.signature(logging.Logger._log).parameters.values()
+                       if param.kind is inspect.Parameter.POSITIONAL_OR_KEYWORD and param.default is not inspect.Parameter.empty]
+
+    def __init__(self, logger, style, extra=None):
+        if style not in logging._STYLES:
+            raise ValueError('Style must be one of: ' + ','.join(logging._STYLES.keys()))
+        super().__init__(logger, extra)
+        self.style = style
+
+    def log(self, level, msg, *args, **kwargs):
+        if self.isEnabledFor(level):
+            if self.style == '{':
+                msg, kwargs = self.process(msg, kwargs)
+                if not isinstance(msg, str):
+                    msg = str(msg)
+                msg = string.Formatter().vformat(msg, args, kwargs)
+                if kwargs:
+                    self._sanitize_kwargs(kwargs)
+                args = ()
+            elif self.style == '$':
+                if isinstance(msg, string.Template):
+                    msg = msg.template
+                msg, kwargs = self.process(msg, kwargs)
+                if not isinstance(msg, str):
+                    msg = str(msg)
+                if args or kwargs:
+                    if len(args) == 1 and isinstance(args[0], collections.abc.Mapping):
+                        map = args[0]
+                        if kwargs:
+                            if not isinstance(map, collections.abc.MutableMapping):
+                                map = dict(map)
+                            map.update(kwargs)
+                    else:
+                        map = kwargs
+                    msg = string.Template(msg).substitute(map)
+                    if kwargs:
+                        self._sanitize_kwargs(kwargs)
+                else:
+                    msg = string.Template(msg).substitute()
+                args = ()
+            else: # if self.style == '%'
+                msg, kwargs = self.process(msg, kwargs)
+            self.logger._log(level, msg, args, **kwargs)
+
+    def _sanitize_kwargs(self, kwargs):
+        del_keys = []
+        for k in kwargs:
+            if k not in self.log_kwarg_names:
+                del_keys.append(k)
+        for k in del_keys:
+            del kwargs[k]
+
+
+def contextdecorator(dec_func):
+    """
+    An alternate to `contextlib.contextmanager` intended to be used only as a decorator.
+
+    To illustrate the difference, `@contextmanager` in decorator form is used to pass "fixed" arguments to the decorator:
+        @contextmanager
+        def decorator(x):
+            <start>
+            try:
+                yield ...
+            finally:
+                <end>
+        @decorator(<x>) # note how decorator is "called" here - decorator's x is "fixed" to always be <x> when foo is called
+        def foo(a, b):
+            ...
+    while `@contextdecorator` is used to pass arguments from a call to the decoree on to the decorator:
+        @contextdecorator
+        def decorator(a, b):
+            <start>
+            try:
+                yield ...
+            finally:
+                <end>
+        @decorator      # note how decorator is NOT "called" here - foo's arguments are passed on to the decorator each call
+        def foo(a, b):
+            ...
+
+    This doesn't really belong in this module, but it's convenient for defining local loggers, e.g.
+        @contextdecorator
+        def with_context(self, id, *args, **kwargs):
+            self.logger = LoggerAdapter(self.__class__.logger, {'context': id})
+            try:
+                yield self.logger
+            finally:
+                del self.logger
+        @with_context
+        def foo(self, id, ...):
+            ...
+    """
+    @contextlib.wraps(dec_func)
+    def helper(func):
+        @contextlib.wraps(func)
+        def inner(*args, **kwargs):
+            with contextlib._GeneratorContextManager(dec_func, args, kwargs):
+                func(*args, **kwargs)
+        return inner
+    return helper
+
+
+class DateFileHandler(logging.FileHandler):
+    """
+    This provides similar functionality to `logging.handlers.TimedRotatingFileHandler`, the main difference being:
+
+    * `DateFileHandler`: always writes to new date suffixed filenames at intervals
+    * `TimedRotatingFileHandler`: always writes to a base filename, then rotates it to the date-suffixed filenames at intervals
+
+    The latter is problematic because the rotation can fail if something else has that base filename opened (e.g. auto backups),
+    which IMO is a bad tradeoff for the advantage of allowing `tail -f` on a single log file.
+    
+    `TimedRotatingFileHandler` also does not make it easy to append another suffix (like a file extension) to the date-suffixed filenames.
+    """
+
+    __slots__ = '_filename_format', '_date_interval', '_rotate_timestamp'
+
+    def __init__(self, filename_format, date_interval=None, *args, **kwargs):
+        self._filename_format = filename_format
+        self._date_interval = date_interval
+        self._rotate_timestamp, filename = self._rotate_timestamp_and_filename(datetime.now())
+        super().__init__(filename, *args, **kwargs)
+
+    def emit(self, record):
+        if self._rotate_timestamp and time.time() > self._rotate_timestamp:
+            self._rotate_timestamp, self.baseFilename = self._rotate_timestamp_and_filename(datetime.fromtimestamp(record.created))
+            old_stream = self.setStream(super()._open())
+            try:
+                old_stream.close()
+            except:
+                traceback.print_exc(file=sys.stderr)
+        super().emit(record)
+
+    def _rotate_timestamp_and_filename(self, date):
+        rotate_timestamp = None
+        if self._date_interval:
+            filename = date.strftime(self._filename_format)
+            if filename != self._filename_format: # if filename_format has any format codes
+                # round current local date according to date format
+                rotate_timestamp = (datetime.strptime(filename, self._filename_format).astimezone() + self._date_interval).timestamp()
+        return (rotate_timestamp, os.path.abspath(filename))
+
+
+def getLogger(name_or_logger=None):
+    """
+    If argument is a `logging.Logger`, returns as-is.
+
+    If argument has a `logger` attribute (such as `logging.LoggerAdapter`), recursively returns `getLogger(argument.logger)`,
+    even if there are multiple nested `LoggerAdapter`s.
+
+    Otherwise, returns `logging.getLogger(argument)`.
+    """
+    if isinstance(name_or_logger, logging.Logger):
+        return name_or_logger
+    # not using logger = getattr(name_or_logger, 'logger', None) since None is a valid getLogger argument (root logger)
+    if hasattr(name_or_logger, 'logger'):
+        logger = name_or_logger.logger
+        if logger != name_or_logger: # avoid infinite loop if name_or_logger.logger refers to itself
+            return getLogger(logger)
+    return logging.getLogger(name_or_logger)
+
+def basicConfig(logger, **kwargs):
+    """
+    `logging.basicConfig` primarily for non-root loggers (although still useful for root logger for lenient style - see below).
+
+    :param propagate: if given, sets logger.propagate to its value.
+
+    If `propagate` keyword arg is given, sets logger.propagate to its value.
+    
+    If `lenient` keyword arg is truthy, effectively decorates this function with `@lenientFormatStyle()`.
+
+    Returns the given logger (now configured) for convenience.
+    """
+    if kwargs.pop('lenient', None):
+        lenient = lenientFormatStyle()
+        ctx_enter = lenient.__enter__
+        ctx_exit = lenient.__exit__
+    else:
+        ctx_enter = logging._acquireLock
+        ctx_exit = logging._releaseLock
+    propagate = kwargs.pop('propagate', None)
+    ctx_enter()
+    orig_root = logging.root
+    try:
+        logging.root = logger
+        logging.basicConfig(**kwargs)
+        if propagate is not None:
+            logger.propagate = propagate
+    finally:
+        logging.root = orig_root
+        ctx_exit()
+    return logger
+
+
+def addLevelName(level, level_name):
+    """
+    Usage (to workaround `pylint` inability to recognize new setattr'd attributes):
+        logging.<NAME>, logging.<name>, logging.Logger.<name>, logging.LoggerAdapter.<name> = logging.addLevelName(<level>, <NAME>)
+
+    More complete version of `logging.addLevelName(<level>, <NAME>)` that also adds (if not yet defined):
+        logging.<NAME> = <level>
+        logging.<name>(msg, *args, **kwargs)
+        logging.Logger.<name>(self, msg, *args, **kwargs)
+        logging.LoggerAdapter.<name>(self, msg, *args, **kwargs)
+    """
+    if not level_name.isupper():
+        raise ValueError(f"Expected all uppercase level name: {level_name}")
+    if not hasattr(logging, level_name) or level_name not in logging._nameToLevel:
+        setattr(logging, level_name, level)
+        logging.addLevelName(level, level_name)
+    func_name = level_name.lower()
+    # need to define separate functions (lambdas here) for each of these, since need separate function instances
+    _def_method(logging, func_name, lambda msg, *args, **kwargs: logging.log(level, msg, *args, **kwargs))
+    _def_method(logging.Logger, func_name, lambda self, msg, *args, **kwargs: self.log(level, msg, *args, **kwargs))
+    _def_method(logging.LoggerAdapter, func_name, lambda self, msg, *args, **kwargs: self.log(level, msg, *args, **kwargs))
+    return getattr(logging, level_name), getattr(logging, func_name), getattr(logging.Logger, func_name), getattr(logging.LoggerAdapter, func_name)
+
+def _def_method(cls, name, func):
+    if not hasattr(cls, name):
+        func.__name__ = name
+        if inspect.ismodule(cls):
+            func.__qualname__ = name
+            func.__module__ = cls.__name__
+        else:
+            func.__qualname__ = f"{cls.__qualname__}.{name}"
+            func.__module__ = cls.__module__
+        setattr(cls, name, func)
+
+
+# for debugging
+def _print_err(*args):
+    print(inspect.currentframe().f_back.f_code.co_name + ':', *args, file=sys.__stderr__, flush=True)


### PR DESCRIPTION
I know you're already working on another branch and already have a solution for the change YouTube endpoint, so these changes can't be merged as-is, but I think you can find use for them.

0. First commit can be ignored - it just adds basic debug logging, and I know your branch has its own more robust version.

1. https://github.com/xenova/chat-downloader/pull/50/commits/24e0d2293e5c1130fce9433b48f744376069d2ad?w=1
The HTTP library already has built-in retry and timeout functionality - they just need to be enabled.
Also ensure output file is always created even on uncaught exception.

* edit: 1.5. https://github.com/xenova/chat-downloader/pull/50/commits/dea15b357fd3611840f5e1b86c25e11dcd6a1a6e?w=1
Improve exception handling (combine try/except & try/finally, flush print), including handling HTTP RequestException.

2. https://github.com/xenova/chat-downloader/pull/50/commits/36b9f8660a85e1cb03e4cde75c578447b88b9902?w=1
Use UTF-8-BOM encoding for file output. This was only needed for MS Excel compatibility with CSV unicode files. I just applied the same encoding to the other file output types for consistency.
Also improve JSON parse error message.

3. https://github.com/xenova/chat-downloader/pull/50/commits/0203b7f5b47c52463b3cd080a8ed0ba5b95af707?w=1
Update to the new YouTube endpoint reusing param data from the `ytcfg` from the original video page. This json snippet includes these key fields: `INNERTUBE_API_VERSION`, `INNERTUBE_API_KEY`, `INNERTUBE_CONTEXT`.
This should be more robust than your solution, since it avoids the need to stub in dummy param data.
This commit also improves regex handling: more robust regex, lenient parsing, compiled regex

* edit: 3.5. https://github.com/xenova/chat-downloader/pull/50/commits/8f451c5a79b6b87a346121a224a2aa0d2f6893fd?w=1
Also added handling for chat continuation returning 404 error (in addition to the handling for 403 error).

4. https://github.com/xenova/chat-downloader/pull/50/commits/f0679f363eb9e01c8c3491a7363106162e71a7bd?w=1
Add `datetime` (ISO format that's never an offset so it's always consistent between live and replay) and `author_type` (language-agnostic enum for member, moderator, owner, etc.) fields.
Also changes the text output format to use `datetime` (rather than `time_text` or converted `timestamp`) and `author_type` (rather than `badges`). I find this more useful for my own purposes, but ideally the text output format should be configurable.


