### PR TITLE
collect emoji id/url

### DIFF
--- a/chat_downloader/sites/common.py
+++ b/chat_downloader/sites/common.py
@@ -455,8 +455,7 @@ class BaseChatDownloader:
 
         new_dict = {}
 
-        keys = (info_keys or info or {}).copy()
-        for key in keys:
+        for key in (info_keys or info or {}).copy():
             if replace_key in key:
                 info_item = info.pop(key, None)
                 new_key = key.replace(replace_key, '')
@@ -465,7 +464,9 @@ class BaseChatDownloader:
                 if info_item not in (None, [], {}):
                     new_dict[new_key] = info_item
 
-        if dict_name not in info and (create_when_empty or new_dict != {}):
+        if dict_name in info:
+            info[dict_name].update(new_dict)
+        elif create_when_empty or new_dict != {}: # dict_name not in info
             info[dict_name] = new_dict
 
         return new_dict

--- a/chat_downloader/sites/youtube.py
+++ b/chat_downloader/sites/youtube.py
@@ -369,16 +369,19 @@ class YouTubeChatDownloader(BaseChatDownloader):
                 emoji = run['emoji']
                 emoji_id = emoji['emojiId']
 
+                name = emoji['shortcuts'][0]
+
                 if emoji_id and emoji_id not in message_emotes:
                     message_emotes[emoji_id] = {
                         'id': emoji_id,
+                        'name': name,
                         'shortcuts': emoji['shortcuts'],
                         'search_terms': emoji['searchTerms'],
                         'images': YouTubeChatDownloader.parse_thumbnails(emoji['image']),
                         'is_custom_emoji': emoji['isCustomEmoji']
                     }
 
-                message_info['message'] += emoji['shortcuts'][0]
+                message_info['message'] += name
 
             else:
                 # unknown run


### PR DESCRIPTION
Hey there! Thanks for keeping up with youtube's changes and congrats on getting it packaged and stuff o/

Ran into a usecase where having all the emoji IDs and URLs would be good, so these changes modify the json `message` key to be a dict of `text` and `emoji` like so:
```patch
@@ -32521,3 +34634,5 @@
         "action_type": "add_chat_item",
-        "message": "\ud83d\ude3a",
+        "message": {
+            "text": "\ud83d\ude3a"
+        },
         "message_id": "CjsKGkNJVEhfWldvek[...]E5Xb0pMQS0zMQ%3D%3D",
@@ -32548,3 +34663,9 @@
         "action_type": "add_chat_item",
-        "message": ":_arsm::_arsr::_arsm::_arsr:",
+        "message": {
+            "text": ":_arsm::_arsr::_arsm::_arsr:",
+            "emoji": {
+                "UCdpUojq0KWZCN9bxXnZwz5w/pSSrXfiTD6-S_APZmoPgBg :_arsm:": "https://yt3.ggpht.com/0qcQMMGlKOtD3x4zS3OluvcghDAElHQ2sYE25T_R-lMb3zh7DacH4xkEqFOXxDTBPlQdqYaC4Q",
+                "UCdpUojq0KWZCN9bxXnZwz5w/yyOrXaqoH4ep_AOBjq7oDA :_arsr:": "https://yt3.ggpht.com/9Q3PbGhT37--fiX2KcWRJGZ25iaJiJXSWdFSnkN-3yfh-HI8AHsKrffC7NiNwD8uRA5IaGTofiA"
+            }
+        },
         "message_id": "CjoKGkNQR2VocGFvek80Q0[...]2dvZG9na0Y3QS02",
```

I don't feel too good about modifying the output format like that -- would much rather have it as a separate `emoji` key next to `message`, but could't think of a clean way to do that... Hm, maybe `_REMAPPING` could take a list of remappers/outputs for a single source key, like `'message': [('message', 'parse_runs'), ('emoji', 'parse_emoji')]`?

Another thing I really wanted to do was gather up all the URLs to deduplicate them, saving them up for a new action_type at the end, but ended up drawing a blank there too. Maybe you have some great ideas :>

Oh and the intention is to also maintain an archive of all emojis in a folder (named after their id probably), but I'm leaning towards doing that in a separate project since that's kinda out of scope for chat-downloader right?