### PR TITLE
[YouTube] Parse superchat amounts (#64)

### DIFF
--- a/chat_downloader/formatting/custom_formats.json
+++ b/chat_downloader/formatting/custom_formats.json
@@ -1,6 +1,6 @@
 {
     "default": {
-        "template": "{time_text|timestamp}{author.badges}{amount}{author.display_name|author.name}{message}",
+        "template": "{time_text|timestamp}{author.badges}{money.text}{author.display_name|author.name}{message}",
         "keys": {
             "time_text": "{} | ",
             "timestamp": {
@@ -11,7 +11,7 @@
                 "template": "({}) ",
                 "separator": ", "
             },
-            "amount": "*{}* ",
+            "money.text": "*{}* ",
             "message": ": {}"
         }
     },


### PR DESCRIPTION
Superchat messages with an amount attached are now parsed, returning a `money` dictionary containing:
- text: text used for display purposes
- amount: float value of money
- currency: ISO 4217 currency code (e.g. USD) 
- currency_symbol: currency symbol (e.g. $)