### PR TITLE
Flush stdout after every message

### DIFF
--- a/chat_downloader/chat_downloader.py
+++ b/chat_downloader/chat_downloader.py
@@ -382,7 +382,7 @@ def run(propagate_interrupt=False, **kwargs):
                 pass
         else:
             def callback(item):
-                safe_print(chat.format(item))
+                safe_print(chat.format(item), flush=True)
 
         for message in chat:
             callback(message)


### PR DESCRIPTION
Stdout will block-buffer if it is redirected, which affects capturing/saving stdout with a program like tee. This makes it so messages are printed as they are received, even if stdout isn't a tty.