### PR TITLE
Add missing currency symbols to dictionary

### DIFF
--- a/chat_downloader/sites/youtube.py
+++ b/chat_downloader/sites/youtube.py
@@ -778,6 +778,8 @@ class YouTubeChatDownloader(BaseChatDownloader):
         '£': 'GBP',
         '€': 'EUR',
         '₹': 'INR',
+        '₪': 'ILS',
+        '₱': 'PHP',
 
         '₩': 'KRW',
         '￦': 'KRW',
@@ -788,7 +790,7 @@ class YouTubeChatDownloader(BaseChatDownloader):
 
     # All other currency symbols use the ISO 4217 format:
     # https://en.wikipedia.org/wiki/ISO_4217
-    # e.g. 'CHF', 'COP', 'HUF', 'PHP', 'PLN', 'RUB', 'SEK', 'PEN', 'ARS', 'CLP', 'NOK', 'BAM', 'SGD'
+    # e.g. 'CHF', 'COP', 'HUF', 'PLN', 'RUB', 'SEK', 'PEN', 'ARS', 'CLP', 'NOK', 'BAM', 'SGD'
 
     @ staticmethod
     def _parse_currency(item):


### PR DESCRIPTION
I saw in a streamer's video that the peso comes up as PHP, but on my client at least it appears as ₱. That might be the work of their OBS plugin or it might be region dependent. I haven't checked. It doesn't matter either way since the additional symbols won't break anything. I just found it curious.