### PR TITLE
Fix disabling writer

### DIFF
--- a/chat_downloader/output/continuous_write.py
+++ b/chat_downloader/output/continuous_write.py
@@ -215,7 +215,6 @@ class ContinuousWriter:
         if not self.lazy_initialise:
             self._real_init()
 
-        self.writer=None
     def __getattr__(self, name):
         if name in self.data:
             return self.data[name]


### PR DESCRIPTION
I am not sure if this is the intended code or just a typo.
At the very least, this part of the code seems to make it impossible for a third party to read the contents of the writer.
If this is the intended code, I would like to know why you did it that way and what the alternative is.

Relevant issues: #119