### PR TITLE
Fix disabling writer

### DIFF
--- a/chat_downloader/output/continuous_write.py
+++ b/chat_downloader/output/continuous_write.py
@@ -215,7 +215,6 @@ class ContinuousWriter:
         if not self.lazy_initialise:
             self._real_init()
 
-        self.writer=None
     def __getattr__(self, name):
         if name in self.data:
             return self.data[name]

--- a/chat_downloader/output/continuous_write.py
+++ b/chat_downloader/output/continuous_write.py
@@ -208,7 +208,7 @@ class ContinuousWriter:
         self.overwrite = overwrite
         self.format = format
         self.lazy_initialise = lazy_initialise
-
+        self.writer = None
         self.data.update(kwargs)
 
         self._initialised = False


### PR DESCRIPTION
Thank you for creating a great library.
The writer is set to None in `continuous_write.py`, so the tool that reads the contents of the writer and customizes it doesn't seem to work anymore.
It would be great if you could fix this if possible.
