### PR TITLE
Add superchat to default message groups of YouTube

### DIFF
--- a/chat_downloader/sites/youtube.py
+++ b/chat_downloader/sites/youtube.py
@@ -64,6 +64,7 @@ class YouTubeChatDownloader(BaseChatDownloader):
     _NAME = 'youtube.com'
 
     _SITE_DEFAULT_PARAMS = {
+        'message_groups': ['messages', 'superchat'],
         'format': 'youtube',
     }
 


### PR DESCRIPTION
After downloading the chat from a live stream, I found that superchats are not included in the output by default, e.g. by simply running the downloader without specifying message types / groups.

I think superchats should be included by default as these messages are still highly related to the stream. If you don't think this is necessary, please consider updating the documentation to explicitly state the default value of included message groups for each site, so it would be more clear to the user, and avoiding later regrets if the live chat turned unavailable before the user realizing that not all the messages are downloaded (basically what happened to me this time).