### PR TITLE
Fix cannot get ytInitialPlayerResponse data in Youtube membership stream

### DIFF
--- a/chat_downloader/sites/youtube.py
+++ b/chat_downloader/sites/youtube.py
@@ -418,8 +418,7 @@ class YouTubeChatDownloader(BaseChatDownloader):
     _YT_INITIAL_BOUNDARY_RE = r'\s*(?:var\s+meta|</script|\n)'
     _YT_INITIAL_DATA_RE = r'(?:window\s*\[\s*["\']ytInitialData["\']\s*\]|ytInitialData)\s*=\s*({.+?})\s*;' + \
         _YT_INITIAL_BOUNDARY_RE
-    _YT_INITIAL_PLAYER_RESPONSE_RE = r'ytInitialPlayerResponse\s*=\s*({.+?})\s*;' + \
-        _YT_INITIAL_BOUNDARY_RE
+    _YT_INITIAL_PLAYER_RESPONSE_RE = r"""(?:^\s*window\["ytInitialPlayerResponse"\]|var ytInitialPlayerResponse) = (\{.+?\});(?:\s*$|</script>|var )"""
     _YT_CFG_RE = r'ytcfg\.set\s*\(\s*({.+?})\s*\)\s*;'
 
     _YT_HOME = 'https://www.youtube.com'

--- a/chat_downloader/sites/youtube.py
+++ b/chat_downloader/sites/youtube.py
@@ -415,10 +415,11 @@ class YouTubeChatDownloader(BaseChatDownloader):
         }
     ]
 
-    _YT_INITIAL_BOUNDARY_RE = r'\s*(?:var\s+meta|</script|\n)'
+    _YT_INITIAL_BOUNDARY_RE = r'\s*(?:var\s+(?:meta|head)|</script|\n)'
     _YT_INITIAL_DATA_RE = r'(?:window\s*\[\s*["\']ytInitialData["\']\s*\]|ytInitialData)\s*=\s*({.+?})\s*;' + \
         _YT_INITIAL_BOUNDARY_RE
-    _YT_INITIAL_PLAYER_RESPONSE_RE = r"""(?:^\s*window\["ytInitialPlayerResponse"\]|var ytInitialPlayerResponse) = (\{.+?\});(?:\s*$|</script>|var )"""
+    _YT_INITIAL_PLAYER_RESPONSE_RE = r'ytInitialPlayerResponse\s*=\s*({.+?})\s*;' + \
+        _YT_INITIAL_BOUNDARY_RE
     _YT_CFG_RE = r'ytcfg\.set\s*\(\s*({.+?})\s*\)\s*;'
 
     _YT_HOME = 'https://www.youtube.com'


### PR DESCRIPTION
I found `player_response` got empty value in youtube membership stream. Replace old regex with a better regex.
https://github.com/xenova/chat-downloader/issues/145