### PR TITLE
[Twitch-Livestream] emote_id consists of English, numbers and underscores

### DIFF
--- a/chat_downloader/sites/twitch.py
+++ b/chat_downloader/sites/twitch.py
@@ -312,7 +312,7 @@ class TwitchChatDownloader(BaseChatDownloader):
                 emote_image_list.append(image)
         return emote_image_list
 
-    _EMOTE_REGEX = r'(\d+):([\d,-]+)'
+    _EMOTE_REGEX = r'(\w+):([\d,-]+)'
     _EMOTE_URL_TEMPLATE = 'https://static-cdn.jtvnw.net/emoticons/v2/{}/default/{}/{}'
 
     @staticmethod


### PR DESCRIPTION
https://dev.twitch.tv/docs/irc/emotes#getting-channel-emotes

like `emotes=emotesv2_4c3b4ed516de493bbcd2df2f5d450f49:0-22`
`r'(\d+):([\d,-]+)'` will get `49:0-22`
`r'(\w+):([\d,-]+)'` will get `emotesv2_4c3b4ed516de493bbcd2df2f5d450f49:0-22`

* Livestreams has this problem
past broadcasts did not