### PR TITLE
Remove argparse from requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@ with open('README.rst') as readme_file:
 requirements = [
     'requests',
     'isodate',
-    'argparse',
     'docstring-parser',
     'colorlog',
     'websocket-client'


### PR DESCRIPTION
argparse as part of the standard library since Python 3.2, and this
package requires >=3.6, hence it's not necessary to set it as
dependency.