### PR TITLE
[YouTube] Q&A message didn't have `header`

### DIFF
--- a/chat_downloader/sites/youtube.py
+++ b/chat_downloader/sites/youtube.py
@@ -1758,18 +1758,21 @@ class YouTubeChatDownloader(BaseChatDownloader):
 
                             header = original_item[original_message_type].get(
                                 'header')
-                            parsed_header = self._parse_item(
-                                header, offset=offset)
-                            header_message = parsed_header.get('message')
+                            if header:
+                                parsed_header = self._parse_item(
+                                    header, offset=offset)
+                                header_message = parsed_header.get('message')
 
                             contents = original_item[original_message_type].get(
                                 'contents')
                             parsed_contents = self._parse_item(
                                 contents, offset=offset)
 
-                            data.update(parsed_header)
+                            if header:
+                                data.update(parsed_header)
                             data.update(parsed_contents)
-                            data['header_message'] = header_message
+                            if header:
+                                data['header_message'] = header_message
                         else:
                             debug_log(
                                 'No bannerRenderer item',


### PR DESCRIPTION
`liveChatCallForQuestionsRenderer` didn't have `header` in https://github.com/xenova/chat-downloader/blob/657e56eeec4ebe5af28de66b4d3653dbb796c8c1/chat_downloader/sites/youtube.py#L1759

```cmd
Traceback (most recent call last):
  File "c:\users\test01\appdata\local\programs\python\python39\lib\runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "c:\users\test01\appdata\local\programs\python\python39\lib\runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "C:\Users\test01\AppData\Local\Programs\Python\Python39\Scripts\chat_downloader.exe\__main__.py", line 7, in <module>
  File "c:\users\test01\appdata\local\programs\python\python39\lib\site-packages\chat_downloader\cli.py", line 194, in main
    run(**args.__dict__)
  File "c:\users\test01\appdata\local\programs\python\python39\lib\site-packages\chat_downloader\chat_downloader.py", line 360, in run
    for message in chat:
  File "c:\users\test01\appdata\local\programs\python\python39\lib\site-packages\chat_downloader\sites\common.py", line 283, in __next__
    item = next(self.chat)
  File "c:\users\test01\appdata\local\programs\python\python39\lib\site-packages\chat_downloader\sites\youtube.py", line 1762, in _get_chat_messages
    parsed_header = self._parse_item(
  File "c:\users\test01\appdata\local\programs\python\python39\lib\site-packages\chat_downloader\sites\youtube.py", line 633, in _parse_item
    item_info = item.get(item_index)
AttributeError: 'NoneType' object has no attribute 'get'
```