### PR TITLE
[youtube] Ignore redundant 'authorUsername' field

### DIFF
--- a/chat_downloader/sites/youtube.py
+++ b/chat_downloader/sites/youtube.py
@@ -960,7 +960,10 @@ class YouTubeChatDownloader(BaseChatDownloader):
         'header', 'contents', 'actionId',
 
         # tooltipRenderer
-        'dismissStrategy', 'suggestedPosition', 'promoConfig'
+        'dismissStrategy', 'suggestedPosition', 'promoConfig',
+
+        # redundant field for ticker renderer
+        'authorUsername',
     ]
 
     _KNOWN_KEYS = set(list(_REMAPPING.keys()) +


### PR DESCRIPTION
A quick analysis suggests this is the exact same as authorName, just duplicated to the ticker renderer to enable it to show the superchatter's name. Thus, it can be safely ignored.