### PR TITLE
Add support for Docker

### DIFF
--- a/.github/workflows/github-image.yml
+++ b/.github/workflows/github-image.yml
@@ -1,0 +1,52 @@
+name: Github Registry
+
+on:
+  push:
+    branches: 
+      - '**'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:          
+  build:
+    name: Push Docker Image to Github Registry
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3.0.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@31cebacef4805868f9ce9a0cb03ee36c32df2ac4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/github-image.yml
+++ b/.github/workflows/github-image.yml
@@ -46,7 +46,7 @@ jobs:
         id: build-and-push
         uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56
         with:
-          context: .
+          context: ./docker/
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/README.rst
+++ b/README.rst
@@ -133,7 +133,7 @@ Docker
 - **uid** - UserID, map to your desired User ID (fallback to 9001)
 - **gid** - GroupID, map to your desired Group ID (fallback to 9001)
 
-The File will be saved as streamName-YearMonthDate-HourMinuteSecond.json
+The File will be saved as channelName-YearMonthDate-HourMinuteSecond.json
 
 
 ##########

--- a/README.rst
+++ b/README.rst
@@ -126,19 +126,12 @@ For advanced python use-cases and examples, consult the `Python Documentation <h
 
 Docker
 ------
-
-.. code:: console
     
-    /home/download - the place where the file will be saved. Mount it to a desired place with -v option.
-
-    channelURL - the url of the stream you want to record.
-
-    channelName - the name for the stream.
-
-    uid - UserID, map to your desired User ID (fallback to 9001)
-
-    gid - GroupID, map to your desired Group ID (fallback to 9001)
-
+- **/home/download** - the place where the file will be saved. Mount it to a desired place with -v option.
+- **channelURL** - the url of the stream you want to record.
+- **channelName** - the name for the stream.
+- **uid** - UserID, map to your desired User ID (fallback to 9001)
+- **gid** - GroupID, map to your desired Group ID (fallback to 9001)
 
 The File will be saved as streamName-YearMonthDate-HourMinuteSecond.json
 

--- a/README.rst
+++ b/README.rst
@@ -64,7 +64,7 @@ The tool can be used with ``docker``:
 
 .. code:: console
 
-   $ docker run -v /path/to/download/:/home/download/ -e channelURL='https://www.twitch.tv/twitch' -e channelName='twitch' -e uid='1000' -e gid='1000' ghcr.io/xenova/chat-downloader:master
+   $ docker run -v /path/to/download/:/home/download/ -e channelURL='https://www.twitch.tv/twitch' -e channelName='twitch' -e fileFormat='json' -e uid='1000' -e gid='1000' ghcr.io/xenova/chat-downloader:master
 
 
 #####
@@ -130,10 +130,11 @@ Docker
 - **/home/download** - the place where the file will be saved. Mount it to a desired place with -v option.
 - **channelURL** - the url of the stream you want to record.
 - **channelName** - the name for the stream.
+- **fileFormat** - file extension to be used.
 - **uid** - UserID, map to your desired User ID (fallback to 9001)
 - **gid** - GroupID, map to your desired Group ID (fallback to 9001)
 
-The File will be saved as channelName-YearMonthDate-HourMinuteSecond.json
+The File will be saved as channelName-YearMonthDate-HourMinuteSecond.ext
 
 
 ##########

--- a/README.rst
+++ b/README.rst
@@ -60,6 +60,12 @@ Alternatively, the tool can be installed with ``git``:
    $ cd chat-downloader
    $ python setup.py install
 
+The tool can be used with ``docker``:
+
+.. code:: console
+
+   $ docker run -v /path/to/download/:/home/download/ -e channelURL='https://www.twitch.tv/twitch' -e channelName='twitch' -e uid='1000' -e gid='1000' ghcr.io/xenova/chat-downloader:master
+
 
 #####
 Usage
@@ -116,6 +122,25 @@ Python
 
 
 For advanced python use-cases and examples, consult the `Python Documentation <https://chat-downloader.readthedocs.io/en/latest/source/index.html#python-documentation>`_.
+
+
+Docker
+------
+
+.. code:: console
+    
+    /home/download - the place where the file will be saved. Mount it to a desired place with -v option.
+
+    channelURL - the url of the stream you want to record.
+
+    channelName - the name for the stream.
+
+    uid - UserID, map to your desired User ID (fallback to 9001)
+
+    gid - GroupID, map to your desired Group ID (fallback to 9001)
+
+
+The File will be saved as streamName-YearMonthDate-HourMinuteSecond.json
 
 
 ##########

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,24 @@
+FROM python:3.12
+LABEL maintainer="lauwarm@mailbox.org"
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install gosu -y
+
+COPY requirements.txt /app/
+RUN pip install --no-cache-dir -r requirements.txt
+
+RUN  echo 'export PATH="${HOME}/.local/bin:${PATH}"'
+
+COPY . /app
+
+RUN mkdir /home/download
+RUN mkdir /home/script
+
+COPY ./entrypoint.sh /home/script/
+
+RUN ["chmod", "+x", "/home/script/entrypoint.sh"]
+
+ENTRYPOINT [ "/home/script/entrypoint.sh" ]
+
+CMD python download_chat.py ${channelURL} ${channelName}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,4 +21,4 @@ RUN ["chmod", "+x", "/home/script/entrypoint.sh"]
 
 ENTRYPOINT [ "/home/script/entrypoint.sh" ]
 
-CMD python download_chat.py ${channelURL} ${channelName}
+CMD python download_chat.py ${channelURL} ${channelName} ${fileFormat}

--- a/docker/download_chat.py
+++ b/docker/download_chat.py
@@ -1,0 +1,10 @@
+import subprocess, sys
+from datetime import datetime
+
+channel_url = sys.argv[1]
+channel_name = sys.argv[2]
+
+now = datetime.now()
+d1 = now.strftime("%Y%m%d-%H%M%S")
+
+subprocess.run(['chat_downloader', channel_url, '--output', "/home/download/"+channel_name+"-"+d1+'.json'])

--- a/docker/download_chat.py
+++ b/docker/download_chat.py
@@ -3,8 +3,9 @@ from datetime import datetime
 
 channel_url = sys.argv[1]
 channel_name = sys.argv[2]
+file_format = sys.argv[3]
 
 now = datetime.now()
 d1 = now.strftime("%Y%m%d-%H%M%S")
 
-subprocess.run(['chat_downloader', channel_url, '--output', "/home/download/"+channel_name+"-"+d1+'.json'])
+subprocess.run(['chat_downloader', channel_url, '--output', "/home/download/"+channel_name+"-"+d1+'.'+file_format])

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+# Add local user and group
+# Either use the uid and gid if passed in at runtime or
+# fallback to 9001
+
+USER_ID=${uid:-9001}
+GROUP_ID=${gid:-9001}
+
+echo "UID : $USER_ID \nGID : $GROUP_ID"
+
+chown -R $USER_ID:$GROUP_ID /home/script
+
+exec gosu $USER_ID "$@"

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -1,0 +1,1 @@
+chat-downloader==0.2.8

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -64,7 +64,7 @@ The tool can be used with ``docker``:
 
 .. code:: console
 
-   $ docker run -v /path/to/download/:/home/download/ -e channelURL='https://www.twitch.tv/twitch' -e channelName='twitch' -e uid='1000' -e gid='1000' ghcr.io/xenova/chat-downloader:master
+   $ docker run -v /path/to/download/:/home/download/ -e channelURL='https://www.twitch.tv/twitch' -e channelName='twitch' -e fileFormat='json' -e uid='1000' -e gid='1000' ghcr.io/xenova/chat-downloader:master
 
 #####
 Usage
@@ -115,12 +115,14 @@ Docker
 
     channelName - the name for the stream.
 
+    fileFormat - file extension to be used.
+
     uid - UserID, map to your desired User ID (fallback to 9001)
 
     gid - GroupID, map to your desired Group ID (fallback to 9001)
 
 
-The File will be saved as streamName-YearMonthDate-HourMinuteSecond.json
+The File will be saved as streamName-YearMonthDate-HourMinuteSecond.ext
 
 ##########
 Chat Items

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -60,6 +60,11 @@ Alternatively, the tool can be installed with ``git``:
    $ cd chat-downloader
    $ python setup.py install
 
+The tool can be used with ``docker``:
+
+.. code:: console
+
+   $ docker run -v /path/to/download/:/home/download/ -e channelURL='https://www.twitch.tv/twitch' -e channelName='twitch' -e uid='1000' -e gid='1000' ghcr.io/xenova/chat-downloader:master
 
 #####
 Usage
@@ -98,6 +103,24 @@ Python
 
 For advanced python use-cases and examples, consult the :ref:`Python Documentation`.
 
+
+Docker
+------
+
+.. code:: console
+    
+    /home/download - the place where the file will be saved. Mount it to a desired place with -v option.
+
+    channelURL - the url of the stream you want to record.
+
+    channelName - the name for the stream.
+
+    uid - UserID, map to your desired User ID (fallback to 9001)
+
+    gid - GroupID, map to your desired Group ID (fallback to 9001)
+
+
+The File will be saved as streamName-YearMonthDate-HourMinuteSecond.json
 
 ##########
 Chat Items


### PR DESCRIPTION
- Added Dockerfiles to build and run chat-downloader as a container
- Added a Github workflow file to create a package
- The README has been updated with instructions on how to run chat-downloader with docker