### PR TITLE
Added option to output video date as part of the file output

### DIFF
--- a/chat_downloader/sites/common.py
+++ b/chat_downloader/sites/common.py
@@ -201,7 +201,7 @@ class Chat():
     next value is yielded from the object's `chat` generator method.
     """
 
-    def __init__(self, chat=None, title=None, duration=None, status=None, video_type=None, start_time=None, id=None, **kwargs):
+    def __init__(self, chat=None, title=None, duration=None, status=None, video_type=None, start_time=None, id=None, date_time=None, **kwargs):
         """Create a Chat object
 
         :param chat: Generator method for retrieving chat messages, defaults to None
@@ -219,10 +219,13 @@ class Chat():
         :param start_time: Start time of the stream (or upload date of video)
             in UNIX microseconds, defaults to None
         :type start_time: float, optional
+        :param date_time: Date of Stream or clip created, defaults to None
+        :type date_time: str, optional
         """
 
         self.chat = chat
 
+        self.date_time = date_time
         self.title = title
         self.duration = duration
 
@@ -253,7 +256,9 @@ class Chat():
         # Special formatting of output name:
         # Allowed keys are specified here
         # Remove invalid characters from output file name
+        log('info', f'Retrieving chat for "{self.date_time}".')
         self._output_writer.file_name = self._output_writer.file_name.format(
+            date_time=safe_path(self.date_time),
             title=safe_path(self.title),
             id=safe_path(self.id)
         )

--- a/chat_downloader/sites/twitch.py
+++ b/chat_downloader/sites/twitch.py
@@ -1252,6 +1252,7 @@ class TwitchChatDownloader(BaseChatDownloader):
                 "Sorry. Unless you've got a time machine, that content is unavailable.")
         title = video.get('title')
         duration = video.get('lengthSeconds')
+        date_time = video.get('createdAt')
 
         channel_name = multi_get(video, 'owner', 'login')
         self._update_badge_info(channel_name)
@@ -1263,7 +1264,8 @@ class TwitchChatDownloader(BaseChatDownloader):
             duration=duration,
             status='past',
             video_type='video',
-            id=vod_id
+            id=vod_id,
+            date_time=date_time            
         )
 
     def _get_chat_by_clip_id(self, match, params):
@@ -1294,7 +1296,7 @@ class TwitchChatDownloader(BaseChatDownloader):
 
         duration = clip.get('durationSeconds')
         title = f"{clip.get('title')} ({clip_id})"
-
+        date_time = clip.get('createdAt')
         channel_name = multi_get(clip, 'broadcaster', 'login')
         self._update_badge_info(channel_name)
 
@@ -1305,7 +1307,8 @@ class TwitchChatDownloader(BaseChatDownloader):
             duration=duration,
             status='past',
             video_type='clip',
-            id=clip_id
+            id=clip_id,
+            date_time=date_time
         )
 
     _MESSAGE_REGEX = re.compile(

--- a/chat_downloader/sites/youtube.py
+++ b/chat_downloader/sites/youtube.py
@@ -1,4 +1,4 @@
-
+from datetime import datetime
 from .common import (
     BaseChatDownloader,
     Chat,
@@ -2176,10 +2176,12 @@ class YouTubeChatDownloader(BaseChatDownloader):
         :rtype: Chat
         """
         initial_info, ytcfg = self._get_initial_video_info(video_id, params)
+        date_time = initial_info.get('start_time')/1000000
 
         return Chat(
             self._get_chat_messages(initial_info, ytcfg, params),
             id=video_id,
+            date_time=str(datetime.fromtimestamp(date_time)),
             **initial_info
         )
 

--- a/chat_downloader/sites/zoom.py
+++ b/chat_downloader/sites/zoom.py
@@ -1,5 +1,5 @@
 
-
+from datetime import datetime
 import json
 import re
 from .common import (
@@ -117,6 +117,7 @@ class ZoomChatDownloader(BaseChatDownloader):
 
         chat_messages = result.get('meetingChatList') or []
         title = multi_get(result, 'meet', 'topic')
+        date_time = datetime.fromtimestamp(float(result.get('fileStartTime'))/1000)
         return Chat(
             self._get_chat_messages(chat_messages, params),
             title=title,
@@ -124,6 +125,7 @@ class ZoomChatDownloader(BaseChatDownloader):
             start_time=result.get('fileStartTime'),
             id=video_id,
             duration=result.get('duration'),
+            date_time=str(date_time)
         )
 
     def _parse_js_dict(self, json_string):


### PR DESCRIPTION
Added the option to output the video created date to the download chat e.g. running 
`chat_downloader https://zoom.us/rec/play/6ccrIuigqG83GIaT4wSDAv59W9W5J_-s1HUe_6UPykq3V3hVN1emMucTYLEJiA87rIkEPcGptB0Dp_dH --output {date_time}-{title}-chat.txt` will output the file title as `2020-03-26 19_02_44-The History & Principles of Mutual Aid-chat.txt`.
It will use the date that the video reports, so it might not be the actual broadcast date.