### PR TITLE
fix youtube cookie consent check (#238)

### DIFF
--- a/chat_downloader/sites/youtube.py
+++ b/chat_downloader/sites/youtube.py
@@ -1366,7 +1366,7 @@ class YouTubeChatDownloader(BaseChatDownloader):
         if self.get_cookie_value('__Secure-3PSID'):
             return
         socs = self.get_cookie_value('SOCS')
-        if socs and not socs.value.startswith('CAA'):  # not consented
+        if socs and not str(socs).startswith('CAA'):  # not consented
             return
         self.set_cookie_value('.youtube.com', 'SOCS', 'CAI', secure=True)  # accept all (required for mixes)
 


### PR DESCRIPTION
this should fix #238 which appears to be occuring for most european(?) users who share youtube cookies between yt-dlp and chat-downloader.

I've made the assumption that `socs.value` was the correct way to retrieve the value in some past version of python, so I'm casting it to a string in an attempt to support both versions :+1: 