### PR TITLE
[youtube] add more currency symbol to the mapping

### DIFF
--- a/chat_downloader/sites/youtube.py
+++ b/chat_downloader/sites/youtube.py
@@ -822,6 +822,28 @@ class YouTubeChatDownloader(BaseChatDownloader):
 
         '¥': 'JPY',
         '￥': 'JPY',
+
+        "؋": "AFN",
+        "฿": "THB",
+        "₵": "GHS",
+        "₡": "CRC",
+        "₫": "VND",
+        "֏": "AMD",
+        "₲": "PYG",
+        "₴": "UAH",
+        "₭": "LAK",
+        "₾": "GEL",
+        "₺": "TRY",
+        "₼": "AZN",
+        "₦": "NGN",
+        "﷼": "IRR",
+        "៛": "KHR",
+        "₽": "RUB",
+        "₪": "ILS",
+        "⃀": "KGS",
+        "৳": "BDT",
+        "₸": "KZT",
+        "₮": "MNT",
     }
 
     # All other currency symbols use the ISO 4217 format:


### PR DESCRIPTION
I notice that for VND, the currency was displayed as `₫` instead of `VND`. Therefore, I refer to [this wiki page](https://en.wikipedia.org/wiki/Currency_symbol) and added some extra symbol to the `_CURRENCY_SYMBOLS` dict based on symbol that has Unicode representation. Although some symbol might not be actually used in YouTube, it should be beneficial to add a set of extra symbols.