### PR TITLE
Fix YouTube live stream status check logic

### DIFF
--- a/chat_downloader/sites/youtube.py
+++ b/chat_downloader/sites/youtube.py
@@ -1532,7 +1532,7 @@ class YouTubeChatDownloader(BaseChatDownloader):
         }
 
         # live, upcoming or past
-        if video_details.get('isLive') or live_details.get('isLiveNow'):
+        if video_details.get('isLive') or live_details.get('isLiveNow') or live_details.get("isLiveContent"):
             details['status'] = 'live'
 
         elif video_details.get('isUpcoming'):


### PR DESCRIPTION
## Problem Description
The YouTube live stream status check logic was missing the `isLiveContent` condition, causing some live content to be incorrectly classified as 'past' status.

## Solution
- Added `live_details.get("isLiveContent")` condition to improve live content detection accuracy
- Utilizes the `isLiveContent` field provided by YouTube API for more accurate live stream status determination

## Debug Example
Below is an example of `video_details` from a video that had `isLiveContent: true` but was incorrectly classified as 'past' status:

```json
{
  "videoId": "cLNaX6twod4",
  "title": "【LIVE】#573 のんびり農業新生活 【Palia/パリア v0.192】",
  "lengthSeconds": "9831",
  "keywords": [
    "ゲーム実況",
    "game",
    "最新作",
    "正式リリース",
    "生配信",
    "ながら見",
    "作業用",
    "my time at sandrock",
    "スイッチ",
    "フォートナイト",
    "fortnite",
    "lego",
    "レゴ"
  ],
  "channelId": "UC2Auk0sAOiXP7GqOSqIR4lw",
  "isOwnerViewing": false,
  "shortDescription": "ウィークリー！\n再生リスト\nhttps://www.youtube.com/playlist?list=PLa7p6kKzeRGdpMFbDrOJ0VsOY6jpFz-P8\n#ゲーム実況 #Palia #パリア",
  "isCrawlable": true,
  "thumbnail": {
    "thumbnails": [
      {
        "url": "https://i.ytimg.com/vi/cLNaX6twod4/hqdefault.jpg?sqp=-oaymwEbCKgBEF5IVfKriqkDDggBFQAAiEIYAXABwAEG&rs=AOn4CLBazpfSBiaJQg8nt0Xe-cpBh-3C3A",
        "width": 168,
        "height": 94
      },
      {
        "url": "https://i.ytimg.com/vi/cLNaX6twod4/hqdefault.jpg?sqp=-oaymwEbCMQBEG5IVfKriqkDDggBFQAAiEIYAXABwAEG&rs=AOn4CLCW-1IQm5SEK7n4yyAmZDMgoCYrMw",
        "width": 196,
        "height": 110
      },
      {
        "url": "https://i.ytimg.com/vi/cLNaX6twod4/hqdefault.jpg?sqp=-oaymwEcCPYBEIoBSFXyq4qpAw4IARUAAIhCGAFwAcABBg==&rs=AOn4CLAFtcVQLN0__Cjq-AQNHkFawEwQxA",
        "width": 246,
        "height": 138
      },
      {
        "url": "https://i.ytimg.com/vi/cLNaX6twod4/hqdefault.jpg?sqp=-oaymwEcCNACELwBSFXyq4qpAw4IARUAAIhCGAFwAcABBg==&rs=AOn4CLApigpANK5_X0jis7qFcaPKoSeDKA",
        "width": 336,
        "height": 188
      },
      {
        "url": "https://i.ytimg.com/vi/cLNaX6twod4/maxresdefault.jpg?v=686b5062",
        "width": 1920,
        "height": 1080
      }
    ]
  },
  "allowRatings": true,
  "viewCount": "472",
  "author": "みょうがのちゃんねる",
  "isLowLatencyLiveStream": true,
  "isPrivate": false,
  "isUnpluggedCorpus": false,
  "latencyClass": "MDE_STREAM_OPTIMIZATIONS_RENDERER_LATENCY_ULTRA_LOW",
  "isLiveContent": true
}
```

## Impact
With this fix, videos with `isLiveContent: true` will be properly classified as 'live' status instead of being incorrectly marked as 'past'.

## Testing
The fix has been tested with various YouTube live streams and ensures proper status classification.